### PR TITLE
Refresh artists

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -5,7 +5,7 @@ module.exports = () => {
   return {
     name: "VoiceVault",
     slug: "VoiceVault",
-    version: "1.1.6",
+    version: "1.1.7",
     orientation: "portrait",
     icon: "./assets/icon.png",
     userInterfaceStyle: "light",
@@ -18,7 +18,7 @@ module.exports = () => {
     ios: {
       supportsTablet: true,
       bundleIdentifier: "com.can1cyp2.VoiceVault",
-      buildNumber: "1.1.6",
+      buildNumber: "1.1.7",
       infoPlist: {
         NSCameraUsageDescription: "This app uses the camera for user profile images. (Future updates may require this permission.)",
         NSPhotoLibraryUsageDescription: "This app accesses your photo library for profile picture uploads. (Future updates may require this permission.)",
@@ -27,7 +27,7 @@ module.exports = () => {
       }
     },
     android: {
-      versionCode: 10106,
+      versionCode: 10107,
       adaptiveIcon: {
         foregroundImage: "./assets/icon.png",
         backgroundColor: "#ffffff"

--- a/app/screens/HomeScreen/HomeScreen.tsx
+++ b/app/screens/HomeScreen/HomeScreen.tsx
@@ -109,7 +109,7 @@ export default function HomeScreen({ navigation }: HomeScreenProps) {
       <Modal visible={isSignupVisible} transparent animationType="slide">
         <SignupModal onClose={() => setSignupVisible(false)} />
       </Modal>
-      <Text style={styles.versionText}>Version 1.1.6</Text>
+      <Text style={styles.versionText}>Version 1.1.7</Text>
     </View>
   );
 }

--- a/app/screens/SearchScreen/SearchScreen.tsx
+++ b/app/screens/SearchScreen/SearchScreen.tsx
@@ -283,6 +283,14 @@ export default function SearchScreen() {
       {!loading && results.length === 0 && !error && (
         <Text style={styles.noResultsText}>No results found.</Text>
       )}
+      {/* Display "In Range" explanation for artists */}
+      {filter === "artists" && vocalRangeFilterActive && vocalRange && vocalRange.min_range !== "C0" && vocalRange.max_range !== "C0" && (
+        <View style={styles.inRangeExplanationContainer}>
+          <Text style={styles.inRangeExplanationText}>
+            "In Range" for artists means that some songs this artist sings are in your range.
+          </Text>
+        </View>
+      )}
       <FlatList
         data={
           vocalRangeFilterActive
@@ -478,5 +486,16 @@ const styles = StyleSheet.create({
   },
   loadingHeader: {
     paddingVertical: 10,
+  },
+  inRangeExplanationContainer: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    backgroundColor: "#f0f0f0",
+    marginBottom: 5,
+  },
+  inRangeExplanationText: {
+    fontSize: 14,
+    color: "#333",
+    textAlign: "center",
   },
 });


### PR DESCRIPTION
- Added conditional text above FlatList when filter is 'artists' and 'In Range' is active
- Text explains that 'In Range' means some songs by the artist are in the user’s vocal range
- Included checks for valid vocal range (non-'C0') to avoid display with unset ranges
- Added new styles for explanation container and text (inRangeExplanationContainer, inRangeExplanationText)
- Tested text appearance on artist filter switch and 'In Range' toggle with valid/invalid ranges
- Added version number 1.1.7 for next update