### PR TITLE
refactor(admin): extract AdminQuickStats and compute New Today from a…

### DIFF
--- a/app/screens/ProfileScreen/AdminProfileScreen.tsx
+++ b/app/screens/ProfileScreen/AdminProfileScreen.tsx
@@ -17,6 +17,7 @@ import { adService } from "../../components/SupportModal/AdService"; // Import y
 
 import Constants from "expo-constants";
 import * as Updates from "expo-updates";
+import AdminQuickStats from './AdminQuickStats';
 
 // Parse Supabase/Postgres timestamp strings like "2025-06-28 02:54:57.472176+00"
 // into a JS Date reliably across platforms.
@@ -139,6 +140,8 @@ export default function AdminProfileScreen({ navigation }: AdminScreenProps) {
         fetchAdminData();
         setupAdDebugMonitoring();
     }, []);
+
+    // userStats are now provided by a dedicated component (AdminQuickStats)
 
     const addDebugLog = (message: string) => {
         const timestamp = new Date().toLocaleTimeString();
@@ -322,7 +325,7 @@ export default function AdminProfileScreen({ navigation }: AdminScreenProps) {
             }
 
             setAdminDetails(merged as AdminDetails);
-            await fetchUserStats();
+            // stats handled by AdminQuickStats component
         } catch (error) {
             console.error("Error fetching admin data:", error);
             Alert.alert("Error", "Failed to load admin data");
@@ -557,20 +560,7 @@ export default function AdminProfileScreen({ navigation }: AdminScreenProps) {
             {/* Stats Cards */}
             <View style={styles.statsSection}>
                 <Text style={styles.sectionTitle}>Quick Stats</Text>
-                <View style={styles.statsRow}>
-                    <View style={styles.statCard}>
-                        <Text style={styles.statNumber}>{userStats.totalUsers}</Text>
-                        <Text style={styles.statLabel}>Total Users</Text>
-                    </View>
-                    <View style={styles.statCard}>
-                        <Text style={styles.statNumber}>{userStats.activeUsers}</Text>
-                        <Text style={styles.statLabel}>Active Users</Text>
-                    </View>
-                    <View style={styles.statCard}>
-                        <Text style={styles.statNumber}>{userStats.newUsersToday}</Text>
-                        <Text style={styles.statLabel}>New Today</Text>
-                    </View>
-                </View>
+                <AdminQuickStats />
             </View>
 
             {/* Admin Actions */}

--- a/app/screens/ProfileScreen/AdminQuickStats.tsx
+++ b/app/screens/ProfileScreen/AdminQuickStats.tsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, TouchableOpacity } from 'react-native';
+import { supabase } from '../../util/supabase';
+
+export default function AdminQuickStats() {
+    const [loading, setLoading] = useState(true);
+    const [totalUsers, setTotalUsers] = useState<number | null>(null);
+    const [newToday, setNewToday] = useState<number | null>(null);
+    const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetchStats();
+    }, []);
+
+    const fetchStats = async () => {
+        setLoading(true);
+        try {
+            // Prefer server-side RPC which can bypass RLS for admins
+            try {
+                const { data: rpcData, error: rpcError } = await supabase.rpc('admin_get_stats');
+                if (!rpcError && rpcData) {
+                    const row = Array.isArray(rpcData) ? rpcData[0] : rpcData;
+                    setTotalUsers(row?.total_users ?? null);
+                    setNewToday(row?.new_today ?? null);
+                    setLoading(false);
+                    return;
+                }
+                console.log('admin_get_stats RPC not available or denied', rpcError);
+                if (rpcError && !errorMsg) setErrorMsg(rpcError.message || JSON.stringify(rpcError));
+            } catch (rpcEx) {
+                console.log('admin_get_stats RPC failed', rpcEx);
+                if (!errorMsg) setErrorMsg(String(rpcEx));
+            }
+
+            // Fallback: Total users from the auth.users table (may be blocked by RLS)
+            const { count, error } = await supabase
+                .from('auth.users')
+                .select('id', { count: 'exact', head: true });
+
+            if (error) {
+                console.warn('Failed to fetch total users from auth.users:', error);
+                setTotalUsers(null);
+                if (!errorMsg) setErrorMsg(error.message || JSON.stringify(error));
+            } else {
+                setTotalUsers(count ?? null);
+            }
+
+            // Also fetch new users today from auth.users.created_at
+            try {
+                const today = new Date().toISOString().split('T')[0];
+                const { count: todayCount, error: todayError } = await supabase
+                    .from('auth.users')
+                    .select('id', { count: 'exact', head: true })
+                    .gte('created_at', `${today}T00:00:00.000Z`)
+                    .lt('created_at', `${today}T23:59:59.999Z`);
+                if (!todayError) setNewToday(todayCount ?? 0);
+                else if (!errorMsg) setErrorMsg(todayError.message || JSON.stringify(todayError));
+            } catch (e) {
+                // ignore
+            }
+
+            // If newToday is still null, try calling a debug RPC (will help diagnose RLS / schema issues)
+            if (newToday === null) {
+                try {
+                    const { data: dbg, error: dbgErr } = await supabase.rpc('admin_get_stats_debug');
+                    if (!dbgErr && dbg) {
+                        // attach debug info to errorMsg so it appears in logs and UI
+                        const row = Array.isArray(dbg) ? dbg[0] : dbg;
+                        if (!errorMsg) setErrorMsg(`RPC debug: is_admin=${row?.is_admin} caller=${row?.caller} total_users=${row?.total_users} new_today=${row?.new_today}`);
+                    } else if (dbgErr) {
+                        if (!errorMsg) setErrorMsg(dbgErr.message || JSON.stringify(dbgErr));
+                    }
+                } catch (_) {
+                    // ignore
+                }
+            }
+        } catch (e) {
+            console.error('Error fetching admin quick stats', e);
+            setTotalUsers(null);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <View style={styles.row}>
+                <View style={styles.card}>
+                    <ActivityIndicator color="#ff4757" />
+                    <Text style={styles.label}>Total Users</Text>
+                </View>
+                <View style={styles.card}>
+                    <ActivityIndicator color="#ff4757" />
+                    <Text style={styles.label}>Active Users</Text>
+                </View>
+                <View style={styles.card}>
+                    <ActivityIndicator color="#ff4757" />
+                    <Text style={styles.label}>New Today</Text>
+                </View>
+            </View>
+        );
+    }
+
+    return (
+        <>
+            <View style={styles.row}>
+                <View style={styles.card}>
+                    <Text style={styles.number}>{totalUsers ?? '—'}</Text>
+                    <Text style={styles.label}>Total Users</Text>
+                </View>
+                <View style={styles.card}>
+                    <Text style={styles.number}>{'—'}</Text>
+                    <Text style={styles.label}>Active Users</Text>
+                </View>
+                <View style={styles.card}>
+                    <Text style={styles.number}>{newToday ?? '—'}</Text>
+                    <Text style={styles.label}>New Today</Text>
+                </View>
+            </View>
+            <AdminQuickStatsFooter errorMsg={errorMsg} onRetry={fetchStats} />
+        </>
+    );
+}
+
+// Show error message and retry below the stats
+export function AdminQuickStatsFooter({ errorMsg, onRetry }: { errorMsg: string | null; onRetry: () => void }) {
+    if (!errorMsg) return null;
+    return (
+        <View style={styles.footer}>
+            <Text style={styles.errorText}>{errorMsg}</Text>
+            <TouchableOpacity style={styles.retryBtn} onPress={onRetry}>
+                <Text style={styles.retryText}>Retry</Text>
+            </TouchableOpacity>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+    },
+    card: {
+        flex: 1,
+        backgroundColor: 'white',
+        padding: 20,
+        marginHorizontal: 5,
+        borderRadius: 12,
+        alignItems: 'center',
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.1,
+        shadowRadius: 2,
+        elevation: 2,
+    },
+    number: {
+        fontSize: 24,
+        fontWeight: 'bold',
+        color: '#ff4757',
+        marginBottom: 5,
+    },
+    label: {
+        fontSize: 12,
+        color: '#666',
+        textAlign: 'center',
+    },
+    footer: {
+        marginTop: 10,
+        alignItems: 'center',
+    },
+    errorText: {
+        color: '#c0392b',
+        fontSize: 12,
+        marginBottom: 6,
+    },
+    retryBtn: {
+        paddingHorizontal: 14,
+        paddingVertical: 8,
+        backgroundColor: '#ff4757',
+        borderRadius: 8,
+    },
+    retryText: {
+        color: 'white',
+        fontWeight: '600',
+    },
+});

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,19 @@
+Admin SQL helpers
+-----------------
+
+This folder contains SQL helpers for admin functionality used by the app.
+
+Deploying admin_get_stats.sql
+
+1. From your local machine with psql configured against the project database:
+
+   psql "postgresql://<user>:<pass>@<host>:<port>/<db>" -f supabase/sql/admin_get_stats.sql
+
+2. Or use the Supabase CLI:
+
+   supabase db remote set <db-connection-string>
+   supabase db query < supabase/sql/admin_get_stats.sql
+
+Note: The function uses SECURITY DEFINER — ensure the function owner is a
+trusted role. Adjust GRANTs as needed. The function expects an existing
+`check_user_admin_status(uuid)` RPC that returns `is_admin`.


### PR DESCRIPTION
…uth.users

Summary:
- Add a dedicated AdminQuickStats React component.
- RPC-first fetching (admin_get_stats), with a robust fallback that counts today\'s signups from auth.users.created_at (UTC day).
- Show '-' for Active Users; display 0 when there are zero new signups.
- Add small debug footer with Retry to surface RPC/errors during testing. Testing:
- Run Supabase SQL: SELECT * FROM public.admin_get_stats(); (should return total and new_today)
- Open app Admin screen and press Retry to re-run fetchStats().